### PR TITLE
Using uri.fsPath instead of uri.path should fix issue #5

### DIFF
--- a/src/extension/Agent.fs
+++ b/src/extension/Agent.fs
@@ -19,11 +19,11 @@ let createAgent (provider: MyTreeDataProvider) (context : vscode.ExtensionContex
             match cmd with
             | ExplorePackage uri -> 
                 try 
-                    let! doc = client.getPackageInfo uri.path
+                    let! doc = client.getPackageInfo uri.fsPath
                     provider.openOpenXml(doc)
                 with
                 | e -> 
-                    vscode.window.showErrorMessage($"Package '%s{uri.path}' cannot be opened! Error: '%s{e.Message}'", Array.empty<string>) |> ignore
+                    vscode.window.showErrorMessage($"Package '%s{uri.fsPath}' cannot be opened! Error: '%s{e.Message}'", Array.empty<string>) |> ignore
             | ClosePackage document -> 
                 provider.close(document)
             | CloseAllPackages ->


### PR DESCRIPTION
This should fix issue #5: the thing is `uri.path` does not work for Windows paths, but `uri.fsPath` does.